### PR TITLE
New option flags

### DIFF
--- a/main.go
+++ b/main.go
@@ -29,6 +29,7 @@ func main() {
 	flag.StringVar(&release, "release", "", "`id` of release to deploy directly to app")
 	flag.StringVar(&commit, "commit", "", "`SHA` of commit in slug")
 	dryRun := flag.Bool("n", false, "dry run; skip slug upload and release")
+	verbose := flag.Bool("v", false, "dump raw requests and responses from Heroku client")
 	flag.Usage = func() {
 		fmt.Fprintf(os.Stderr, `Usage: %s [arguments]
 
@@ -99,7 +100,7 @@ Available arguments:
 	}
 
 	// Initialize Heroku client
-	c := heroku.Client{Username: user, Password: pass}
+	c := heroku.Client{Username: user, Password: pass, Debug: *verbose}
 	if token != "" {
 		c.AdditionalHeaders = http.Header{"Authorization": {"Bearer " + token}}
 	}

--- a/main.go
+++ b/main.go
@@ -149,14 +149,13 @@ Available arguments:
 		if err != nil {
 			log.Fatal(err)
 		}
+		log.Println("Uploading slug: ", humanize.Bytes(uint64(slugSize)))
 
 		// Put slug data
-		log.Println("Uploading slug: ", humanize.Bytes(uint64(slugSize)))
 		if _, err := f.Seek(0, os.SEEK_SET); err != nil {
 			errlog.Fatal(err)
 		}
-		meth := strings.ToUpper(slug.Blob.Method)
-		req, err := http.NewRequest(meth, slug.Blob.URL, f)
+		req, err := http.NewRequest(strings.ToUpper(slug.Blob.Method), slug.Blob.URL, f)
 		if err != nil {
 			errlog.Fatal(err)
 		}
@@ -172,6 +171,7 @@ Available arguments:
 
 	if !*dryRun {
 		// Release built slug to app
+		log.Println("Releasing slug: ", release)
 		rel, err := c.ReleaseCreate(app, release, nil)
 		if err != nil {
 			errlog.Fatal(err)

--- a/main.go
+++ b/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"bytes"
 	"flag"
 	"fmt"
 	"io/ioutil"
@@ -156,7 +157,8 @@ Available arguments:
 		if _, err := f.Seek(0, os.SEEK_SET); err != nil {
 			errlog.Fatal(err)
 		}
-		req, err := http.NewRequest(strings.ToUpper(slug.Blob.Method), slug.Blob.URL, f)
+		slugBytes, err := ioutil.ReadAll(f)
+		req, err := http.NewRequest(strings.ToUpper(slug.Blob.Method), slug.Blob.URL, bytes.NewReader(slugBytes))
 		if err != nil {
 			errlog.Fatal(err)
 		}

--- a/main.go
+++ b/main.go
@@ -1,10 +1,10 @@
 package main
 
 import (
-	"bytes"
 	"flag"
 	"fmt"
 	"io/ioutil"
+	"log"
 	"net/http"
 	"os"
 	"os/exec"
@@ -19,13 +19,16 @@ import (
 var nameMatch = regexp.MustCompile(`\bname=([^\n]+)`)
 
 func main() {
-	var app, user, pass, token, procFile, slugFile string
-	flag.StringVar(&app, "app", "", "Heroku app name")
-	flag.StringVar(&user, "user", "", "Heroku username")
+	var app, user, pass, token, procFile, slugFile, release, commit string
+	flag.StringVar(&app, "app", "", "Heroku app `name`")
+	flag.StringVar(&user, "user", "", "Heroku `username`")
 	flag.StringVar(&pass, "password", "", "Heroku password")
 	flag.StringVar(&token, "token", "", "Heroku API token")
-	flag.StringVar(&procFile, "procfile", "Procfile", "path to Procfile")
-	flag.StringVar(&slugFile, "slug", "slug.tgz", "path to slug file")
+	flag.StringVar(&procFile, "procfile", "Procfile", "`path` to Procfile")
+	flag.StringVar(&slugFile, "slug", "slug.tgz", "`path` to slug TAR GZIP file")
+	flag.StringVar(&release, "release", "", "`id` of release to deploy directly to app")
+	flag.StringVar(&commit, "commit", "", "`SHA` of commit in slug")
+	dryRun := flag.Bool("n", false, "dry run; skip slug upload and release")
 	flag.Usage = func() {
 		fmt.Fprintf(os.Stderr, `Usage: %s [arguments]
 
@@ -40,12 +43,18 @@ To create a slug from an app directory (./app prefix is required):
 For more information on Heroku and how to create a slug, visit:
 https://devcenter.heroku.com/articles/platform-api-deploying-slugs
 
+Using the -release flag, slugger can deploy to multiple apps in the
+same region with a single upload.
+
 Available arguments:
 `, os.Args[0])
 		flag.PrintDefaults()
 		os.Exit(1)
 	}
 	flag.Parse()
+	errlog := log.New(os.Stderr, "", log.Lshortfile)
+	log.SetFlags(0)
+	log.SetOutput(os.Stderr)
 
 	// Get app name
 	if app == "" {
@@ -55,8 +64,7 @@ Available arguments:
 		cmd := exec.Command("heroku", "info", "--shell")
 		out, err := cmd.Output()
 		if err != nil {
-			fmt.Fprintf(os.Stderr, "Unable to determine app name: `%s': %v\n\n", strings.Join(cmd.Args, " "), err)
-			os.Exit(2)
+			errlog.Fatalf("Unable to determine app name: `%s': %v", strings.Join(cmd.Args, " "), err)
 		}
 		if matches := nameMatch.FindSubmatch(out); len(matches) > 1 {
 			app = string(matches[1])
@@ -65,6 +73,7 @@ Available arguments:
 	if app == "" {
 		flag.Usage()
 	}
+	log.Println("App: ", app)
 
 	// Get auth details
 	if user == "" {
@@ -80,47 +89,14 @@ Available arguments:
 		cmd := exec.Command("heroku", "auth:token")
 		out, err := cmd.Output()
 		if err != nil && user == "" && pass == "" {
-			fmt.Fprintf(os.Stderr, "Unable to determine credentials: `%s': %v\n\n", strings.Join(cmd.Args, " "), err)
-			os.Exit(2)
+			errlog.Fatalf("Unable to determine credentials: `%s': %v", strings.Join(cmd.Args, " "), err)
 		}
 		token = strings.TrimSpace(string(out))
 	}
 	if user == "" && pass == "" && token == "" {
-		fmt.Fprintf(os.Stderr, "Unable to determine credentials.\n\n")
+		errlog.Printf("Unable to determine credentials.")
 		flag.Usage()
 	}
-
-	// Read Procfile
-	f, err := os.Open(procFile)
-	exitif(err)
-	procBytes, err := ioutil.ReadAll(f)
-	f.Close()
-	exitif(err)
-	var processTypes map[string]string
-	err = yaml.Unmarshal(procBytes, &processTypes)
-	exitif(err)
-	procText := strings.Replace(strings.TrimSpace(string(procBytes)), "\n", "\n\t", -1)
-
-	// Read the slug
-	f, err = os.Open(slugFile)
-	exitif(err)
-	slugBytes, err := ioutil.ReadAll(f)
-	f.Close()
-	exitif(err)
-
-	// Get commit ID
-	commit := ""
-	out, err := exec.Command("git", "describe", "--always", "--abbrev", "--dirty").Output()
-	if err == nil {
-		commit = strings.TrimSpace(string(out))
-	}
-	opts := heroku.SlugCreateOpts{Commit: &commit}
-
-	// Log some stuff
-	fmt.Printf("App: %s\n", app)
-	fmt.Printf("Commit: %s\n", commit)
-	fmt.Printf("Processes: %s\n", procText)
-	fmt.Printf("Slug file: %s\n", slugFile)
 
 	// Initialize Heroku client
 	c := heroku.Client{Username: user, Password: pass}
@@ -128,28 +104,81 @@ Available arguments:
 		c.AdditionalHeaders = http.Header{"Authorization": {"Bearer " + token}}
 	}
 
-	// Create a slug
-	slug, err := c.SlugCreate(app, processTypes, &opts)
-	exitif(err)
-	fmt.Printf("Slug ID: %s\n", slug.Id)
-	fmt.Printf("Uploading slug: %s\n", humanize.Bytes(uint64(len(slugBytes))))
+	// Read slug and upload if release isn't known
+	if release == "" {
+		// Read Procfile
+		f, err := os.Open(procFile)
+		if err != nil {
+			errlog.Fatal(err)
+		}
+		procBytes, err := ioutil.ReadAll(f)
+		f.Close()
+		if err != nil {
+			errlog.Fatal(err)
+		}
+		var processTypes map[string]string
+		err = yaml.Unmarshal(procBytes, &processTypes)
+		if err != nil {
+			errlog.Fatal(err)
+		}
+		procText := strings.Replace(strings.TrimSpace(string(procBytes)), "\n", "\n\t", -1)
+		log.Println("Processes: ", procText)
 
-	// Put slug data
-	meth := strings.ToUpper(slug.Blob.Method)
-	req, err := http.NewRequest(meth, slug.Blob.URL, bytes.NewReader(slugBytes))
-	exitif(err)
-	_, err = http.DefaultClient.Do(req)
-	exitif(err)
+		// Open the slug file
+		f, err = os.Open(slugFile)
+		if err != nil {
+			errlog.Fatal(err)
+		}
+		defer f.Close()
+		log.Println("Slug file: ", slugFile)
 
-	// Release
-	rel, err := c.ReleaseCreate(app, slug.Id, nil)
-	exitif(err)
-	fmt.Printf("Deployed version: %d\n", rel.Version)
-}
+		if commit == "" {
+			out, err := exec.Command("git", "describe", "--always", "--abbrev", "--dirty").Output()
+			if err == nil {
+				commit = strings.TrimSpace(string(out))
+			}
+		}
+		log.Println("Commit: ", commit)
 
-func exitif(err error) {
-	if err != nil {
-		fmt.Fprintf(os.Stderr, "Fatal: %s\n", err)
-		os.Exit(1)
+		// Create a slug
+		slug, err := c.SlugCreate(app, processTypes, &heroku.SlugCreateOpts{Commit: &commit})
+		if err != nil {
+			errlog.Fatal(err)
+		}
+		slugSize, err := f.Seek(0, os.SEEK_END)
+		if err != nil {
+			log.Fatal(err)
+		}
+
+		// Put slug data
+		log.Println("Uploading slug: ", humanize.Bytes(uint64(slugSize)))
+		if _, err := f.Seek(0, os.SEEK_SET); err != nil {
+			errlog.Fatal(err)
+		}
+		meth := strings.ToUpper(slug.Blob.Method)
+		req, err := http.NewRequest(meth, slug.Blob.URL, f)
+		if err != nil {
+			errlog.Fatal(err)
+		}
+		if *dryRun {
+			log.Println("Upload skipped (dry run)")
+		} else {
+			if _, err := http.DefaultClient.Do(req); err != nil {
+				errlog.Fatal(err)
+			}
+		}
+		release = slug.Id
 	}
+
+	if !*dryRun {
+		// Release built slug to app
+		rel, err := c.ReleaseCreate(app, release, nil)
+		if err != nil {
+			errlog.Fatal(err)
+		}
+		log.Println("Deployed version: ", rel.Version)
+	}
+
+	fmt.Fprint(os.Stderr, "Slug ID: ")
+	fmt.Println(release)
 }


### PR DESCRIPTION
- `-n` for dry run
- `-commit SHA` to label the uploaded slug with a known SHA
- `-release ID` to allow releasing a previously-uploaded slug to another app
- `-v` for debugging
